### PR TITLE
Fix exploratory vis plots and add post-ta2 plots

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "babel-preset-es2015": "^6.24.1",
     "bootstrap": "^3.3.7",
     "bootswatch": "^3.3.7",
-    "vega": "3.0.9",
-    "vega-scenegraph": "2.1",
-    "vega-wordcloud": "2.0.2",
     "candela": "^0.17.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.4",
@@ -60,6 +57,11 @@
     "style-loader": "^0.18.2",
     "telegraph-events": "^1.0.3",
     "url-loader": "^0.5.9",
+    "vega": "3.0.9",
+    "vega-embed": "^3.0.0",
+    "vega-lite": "^2.1.2",
+    "vega-scenegraph": "2.1",
+    "vega-wordcloud": "2.0.2",
     "webpack": "^3.0.0",
     "yaml-loader": "^0.4.0"
   }

--- a/src/index.jade
+++ b/src/index.jade
@@ -10,7 +10,7 @@ ul.nav.nav-tabs
   li: a(href="#variables" data-toggle="tab" aria-expanded="true") Variables
   li: a(href="#exploratory-vis" data-toggle="tab" aria-expanded="true") Exploratory Vis
   li: a(href="#ta2" data-toggle="tab" aria-expanded="true") TA2
-  //-li: a(href="#post-ta2-vis" data-toggle="tab" aria-expanded="true") Model Output Vis
+  li: a(href="#post-ta2-vis" data-toggle="tab" aria-expanded="true") Model Output Vis
   //-li: a(href="#modeling" data-toggle="tab" aria-expanded="true") Modeling
   li: a(href="#stopping" data-toggle="tab" aria-expanded="true") Quit
 
@@ -33,8 +33,8 @@ ul.nav.nav-tabs
   //-#modeling.tab-pane.fade.in
     //-include template/modeling.jade
 
-  //-#post-ta2-vis.tab-pane.fade.in
-    //-include template/post-ta2-vis.jade
+  #post-ta2-vis.tab-pane.fade.in
+    include template/post-ta2-vis.jade
 
   #stopping.tab-pane.fade.in
     include template/stopping.jade

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import { select,
 import { json } from 'd3-request';
 import dl from 'datalib';
 import Remarkable from 'remarkable';
+// import * as vl from 'vega-lite';
+// import * as vegaEmbed from 'vega-embed'
 
 import { action,
          store,
@@ -537,6 +539,18 @@ observeStore(next => {
           name: d
         }));
 
+        // use vega-lite instead of candela because we need more flexibility
+        // (need scales to not always include zero)
+        const pspec = {
+          "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+          "data": { "values" : data },
+          "mark": "circle",
+          "encoding": {
+            "x": {"field": vars[featureIndex].name, "type": "quantitative", "scale": {"zero": false}},
+            "y": {"field": yVar.name, "type": "quantitative", "scale": {"zero": false}}
+          }
+        }
+
         // add a new Div inside the #scatterplotmatrix element
         jQuery('<h5/>', {
           text: vars[featureIndex].name,
@@ -547,14 +561,21 @@ observeStore(next => {
 
         // create a new plot for this variable combination
         var plotElement = document.getElementById(vars[featureIndex].name)
-        const vismatrix = new ScatterPlot(plotElement, { // eslint-disable-line no-unused-vars
-          data,
-          x: vars[featureIndex].name,
-          y: yVar.name,
-          width: 400*plotSizeScale,
-          height: 400*plotSizeScale
-        });
-        vismatrix.render();
+        vegaEmbed("#" + vars[featureIndex].name, pspec,
+          {
+            "actions": false,
+            "height": 400*plotSizeScale / 2,
+            "width": 400*plotSizeScale / 2
+          });
+
+        // const vismatrix = new ScatterPlot(plotElement, { // eslint-disable-line no-unused-vars
+        //   data,
+        //   x: vars[featureIndex].name,
+        //   y: yVar.name,
+        //   width: 400*plotSizeScale,
+        //   height: 400*plotSizeScale
+        // });
+        // vismatrix.render();
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -54,10 +54,10 @@ json('/config', cfg => {
 
   // now that we have the config information, store the problems to be solved
   json('/dataset/problems', (error,problem_contents) => {
-    console.log('ajax return:',problem_contents)
+    console.log('ajax return:', problem_contents)
     //store.dispatch(action.setProblemDescription(problem_contents['description']));
     store.dispatch(action.setProblemId(problem_contents[0]['problemId']));
-    store.dispatch(action.setProblemTaskType(problem_contents[0]['taskType'])); 
+    store.dispatch(action.setProblemTaskType(problem_contents[0]['taskType']));
     store.dispatch(action.setProblemTaskSubType(problem_contents[0]['taskSubType']));
     store.dispatch(action.setProblemMetrics(problem_contents[0]['metrics']));
     store.dispatch(action.setProblemTargetFeatures(problem_contents[0]['targets']));
@@ -146,7 +146,7 @@ select('button.train').on('click', () => {
   // disabling dynamic discovery for now because it is being set during evaluitions
   //const model = ta2.get('model');
   //const port = model.get('port');
- 
+
   const data_uri = store.getState().getIn(['data', 'data']);
   const task_type = store.getState().getIn(['problems', 'tasktype']);
   const task_subtype = store.getState().getIn(['problems', 'tasksubtype']);
@@ -169,7 +169,7 @@ select('button.train').on('click', () => {
     max_pipelines
   };
   console.log('pipeline params:',params)
-  
+
   let query = [];
   for (let x in params) {
     if (params.hasOwnProperty(x)) {
@@ -225,7 +225,7 @@ observeStore(next => {
 
 
 
-let yVarDropdown = new Dropdown(select('#x-dropdown').node(), {
+let yVarDropdown = new Dropdown(select('#y-dropdown').node(), {
   buttonText: 'Target Variable',
   onSelect: item => {
     store.dispatch(action.setExploratoryVar(0, item));
@@ -242,9 +242,15 @@ let yVarDropdown = new Dropdown(select('#x-dropdown').node(), {
 
 const varsChanged = (origVars, logVars) => {
   const vars = [].concat(origVars, logVars);
-
+  const colIndex = store.getState().getIn(['problem', 'targets', 0, 'colIndex']);
   // Fill the variable menus in the exploratory vis section.
-  yVarDropdown.setItems(vars, d => d.name);
+  yVarDropdown.setItems(vars, (d, i) => {
+    let nm = d.name;
+    if (i === colIndex) {
+      nm = `${nm} *`;
+    }
+    return nm;
+  });
   //yVarDropdown.setItems(vars, d => d.name);
 };
 
@@ -336,24 +342,24 @@ observeStore(next => {
     });
 }, s => s.get('vars'));
 
-// When the list of problems changes, populate the problems tab menu.
-let problemDropdown = new Dropdown(select('#problemdropdown').node(), {
-  buttonText: 'Problem',
-  onSelect: prob => {
-    select('.description')
-      .html(md.render(prob.description));
+// // When the list of problems changes, populate the problems tab menu.
+// let problemDropdown = new Dropdown(select('#problemdropdown').node(), {
+//   buttonText: 'Problem',
+//   onSelect: prob => {
+//     select('.description')
+//       .html(md.render(prob.description));
 
-    select('.metadata')
-      .append(d => stringToElement(metadataTemplate({
-        metadata: prob.metadata
-      })));
+//     select('.metadata')
+//       .append(d => stringToElement(metadataTemplate({
+//         metadata: prob.metadata
+//       })));
 
-    //json(`/dataset/data/${prob.dataFile}`, data => {
-    json('/dataset/datatesting', data => {
-      store.dispatch(action.setActiveData(data.data, data.name, data.path, data.meta));
-    });
-  }
-});
+//     //json(`/dataset/data/${prob.dataFile}`, data => {
+//     json('/dataset/datatesting', data => {
+//       store.dispatch(action.setActiveData(data.data, data.name, data.path, data.meta));
+//     });
+//   }
+// });
 
 /*
 observeStore(next => {
@@ -702,8 +708,8 @@ observeStore(next => {
     })));
 
   // when the predict button is selected, then connect to the TA2 by calling a tangelo service
-  // to make the GRPC API handshake.   The parameters needed to create an analysis pipeline are 
-  // gathered here,  packed into a query object, and sent to the service. 
+  // to make the GRPC API handshake.   The parameters needed to create an analysis pipeline are
+  // gathered here,  packed into a query object, and sent to the service.
 
   const predict = panels.select('.predict')
     .on('click', d => {

--- a/src/index.template.ejs
+++ b/src/index.template.ejs
@@ -2,6 +2,9 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <script src="https://cdn.jsdelivr.net/npm/vega@3.0.10"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@2.1.2"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@3.0.0"></script>
   </head>
   <body>
   </body>

--- a/src/redux/store/index.js
+++ b/src/redux/store/index.js
@@ -11,7 +11,9 @@ const logger = createLogger({
   collapsed: () => true,
   diff: true
 });
-const store = createStore(reducer, applyMiddleware(thunk, promise, logger));
+const store = createStore(reducer,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+  applyMiddleware(thunk, promise, logger));
 
 // Taken from https://github.com/reactjs/redux/issues/303#issuecomment-125184409
 //

--- a/src/template/exploratory-vis.jade
+++ b/src/template/exploratory-vis.jade
@@ -18,10 +18,10 @@
           | between the two variables
 
         p(style='margin-left:40;margin-top:50;margin-right:50')
-          | Select the target variable below to generate the plots (TODO: automatically
-          | set this according to the problem declaration.
+          | Select the target variable below to generate the plots. Note that the suggested
+          | target variable for this problem will have an asterisk next to it in the list.
         .btn-group
-          #x-dropdown
+          #y-dropdown
 
     .row(style='margin-top:50')
       .col-md-10

--- a/src/template/post-ta2-vis.jade
+++ b/src/template/post-ta2-vis.jade
@@ -1,0 +1,22 @@
+.container-fluid
+  .exploratory-vis
+
+    .row(style='margin-top:150')
+      .col-md-10
+        h4 Investigate Model Output
+        p(style='margin-left:40;margin-top:50;margin-right:50')
+          | The prediction algorithm returns a set of predicted values. These can be
+          | viewed with respect to the original data to evaluate the goodness of fit.
+          | A good fit will follow the patterns in the data without being too noisy.
+        p(style='margin-left:40;margin-top:50;margin-right:50')
+          | We can also visualize the residuals for the model fit, which is the actual
+          | observed values subtracted from the predicted values. For a well-fitting
+          | model, the residuals should vary randomly around zero.
+        .btn-group
+          button.btn.btn-default#run-post-vis View Plots
+
+    .row(style='margin-top:50')
+      .col-md-10
+        #scatterplotmatrix2
+
+


### PR DESCRIPTION
There are a lot of changes here. I swapped out candela for vega-lite for the exploratory vis plots because there wasn't enough flexibility (at least that I was aware of) to not have the scales forced to extend to zero.

I also added in a new tab for visualizing predicted values and residuals. I hard coded the target variable and used a terrible prediction method (you'll see jagged lines in a lot of the plots), but the functionality is there. I used vega-lite again because we needed multiple layers on the actual/predicted plot.